### PR TITLE
Add 'Projects' section to theme

### DIFF
--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -1,0 +1,57 @@
+import { ResumeSchema } from '/@/types/resume'
+import { SectionHeader } from '/@/components/partials/section-header'
+import { Title } from '/@/components/partials/title'
+
+type ProjectsProps = {
+    resumeProjects?: ResumeSchema['projects']
+}
+
+export function Projects({ resumeProjects }: ProjectsProps) {
+    if (resumeProjects === undefined || resumeProjects.length == 0) {
+        return null
+    }
+
+    const projectItems = resumeProjects.map((proj, i) => {
+        let projTag = null
+        if (proj.publisher !== undefined) {
+            projTag = <h5 class="awarder">{proj.publisher}</h5>
+        }
+
+        let summaryTag = null
+        if (proj.summary !== undefined) {
+            summaryTag = <p class="summary">{proj.summary}</p>
+        }
+
+        let highlightItems = null
+        if (proj.highlights !== undefined && proj.highlights.length > 0) {
+            highlightItems = (
+                <ul>
+                    {proj.highlights.map((highlight, i) => (
+                        <li key={i}>{highlight}</li>
+                    ))}
+                </ul>
+            )
+        }
+
+        return (
+            <section class="item" key={i}>
+                <SectionHeader
+                    name={proj.name}
+                    startDate={proj.startDate}
+                    endDate={proj.endDate}
+                    website={proj.url}
+                />
+                {projTag}
+                {summaryTag}
+                {highlightItems}
+            </section>
+        )
+    })
+
+    return (
+        <div class="container work-container">
+            <Title value="Projects" />
+            {projectItems}
+        </div>
+    )
+}

--- a/src/resume.tsx
+++ b/src/resume.tsx
@@ -4,6 +4,7 @@ import { Awards } from '/@/components/awards'
 import { Education } from '/@/components/education'
 import { Interests } from '/@/components/interests'
 import { Languages } from '/@/components/languages'
+import { Projects } from '/@/components/projects'
 import { Publications } from '/@/components/publications'
 import { References } from '/@/components/references'
 import { ResumeHeader } from '/@/components/resume-header'
@@ -39,6 +40,7 @@ export function Resume({ resume, countryFormatters }: ResumeProps) {
                     <Education resumeEducation={resume.education} />
                     <Awards resumeAwards={resume.awards} />
                     <Publications resumePublications={resume.publications} />
+                    <Projects resumeProjects={resume.projects} />
                     <References resumeReferences={resume.references} />
                 </div>
             </div>


### PR DESCRIPTION
Added an initial Projects section to the theme, using the same style and templating as the Work section.
Will eventually need to customize this based on the additional fields available in the `projects` spec in the JSON Resume schema