### PR TITLE
Fix incorrect rendering of summaries in `Projects` and `Volunteer`

### DIFF
--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -18,9 +18,9 @@ export function Projects({ resumeProjects }: ProjectsProps) {
             entityTag = <h5 class="awarder">{proj.entity}</h5>
         }
 
-        let summaryTag = null
-        if (proj.summary !== undefined) {
-            summaryTag = <p class="summary">{proj.description}</p>
+        let descriptionTag = null
+        if (proj.description !== undefined) {
+            descriptionTag = <p class="summary">{proj.description}</p>
         }
 
         let highlightItems = null
@@ -43,7 +43,7 @@ export function Projects({ resumeProjects }: ProjectsProps) {
                     website={proj.url}
                 />
                 {entityTag}
-                {summaryTag}
+                {descriptionTag}
                 {highlightItems}
             </section>
         )

--- a/src/components/volunteer.tsx
+++ b/src/components/volunteer.tsx
@@ -19,7 +19,7 @@ export function Volunteer({ resumeVolunteer }: VolunteerProps) {
 
         let summaryTag = null
         if (volunteer.summary !== undefined) {
-            summaryTag = <p class="summary">{summaryTag}</p>
+            summaryTag = <p class="summary">{volunteer.summary}</p>
         }
 
         let highlightItems = null


### PR DESCRIPTION
Adjusted logic in `Projects` to handle the correct rendering of the `description` field.
Adjusted logic in `Volunteer` to handle proper rendering of the summary items.