### PR TITLE
Add customizable ordering of resume sections

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,14 +2,16 @@ import { render as preactRender } from 'preact-render-to-string'
 import { loadCountryFormatters } from '/@/helpers/utils'
 import { Resume } from '/@/resume'
 import type { ResumeSchema } from '/@/types/resume'
-import { ColdbrewResumeMeta } from '/@/types/resume-meta'
+import type { ColdbrewResumeMeta } from '/@/types/resume-meta'
 import resumeStyle from '/@/styles/main.scss?inline'
 
 export async function render(resume: ResumeSchema | object): Promise<string> {
+    // TODO: validatation of resume
     const _resume = resume as ResumeSchema
     const coldbrewMeta = _resume.meta as ColdbrewResumeMeta | undefined
     const locale = coldbrewMeta?.coldbrewTheme?.locale ?? 'en'
 
+    // this is done outside of the components to avoid async logic in Preact
     const localeCountries = await loadCountryFormatters(locale)
 
     const resumeHtml = (
@@ -31,7 +33,7 @@ export async function render(resume: ResumeSchema | object): Promise<string> {
                 <style dangerouslySetInnerHTML={{ __html: resumeStyle }} />
             </head>
             <body>
-                <Resume resume={resume} countryFormatters={localeCountries} />
+                <Resume resume={_resume} countryFormatters={localeCountries} />
             </body>
         </html>
     )

--- a/src/resume.tsx
+++ b/src/resume.tsx
@@ -13,6 +13,7 @@ import { Summary } from '/@/components/summary'
 import { Volunteer } from '/@/components/volunteer'
 import { Work } from '/@/components/work'
 import type { ResumeSchema } from '/@/types/resume'
+import type { ColdbrewResumeMeta } from '/@/types/resume-meta'
 
 type ResumeProps = {
     resume: ResumeSchema
@@ -20,29 +21,59 @@ type ResumeProps = {
 }
 
 export function Resume({ resume, countryFormatters }: ResumeProps) {
+    // TODO: validatation of resume
+    const coldbrewMeta = resume.meta as ColdbrewResumeMeta | undefined
+
+    // allow customization of section ordering
+    // NOTE: this allows repeated sections, and omission of sections
+    const sidebarOrder = coldbrewMeta?.coldbrewTheme?.sidebarOrder || [
+        'about',
+        'skills',
+        'languages',
+        'interests',
+    ]
+    const mainSectionOrder = coldbrewMeta?.coldbrewTheme?.mainSectionOrder || [
+        'summary',
+        'work',
+        'volunteer',
+        'education',
+        'awards',
+        'publications',
+        'projects',
+        'references',
+    ]
+    const sidebarMapping = {
+        about: (
+            <About
+                resumeBasics={resume.basics}
+                countryFormatters={countryFormatters}
+            />
+        ),
+        skills: <Skills resumeSkills={resume.skills} />,
+        languages: <Languages resumeLanguages={resume.languages} />,
+        interests: <Interests resumeInterests={resume.interests} />,
+    }
+    const mainSectionMapping = {
+        summary: <Summary resumeSummary={resume.basics?.summary} />,
+        work: <Work resumeWork={resume.work} />,
+        volunteer: <Volunteer resumeVolunteer={resume.volunteer} />,
+        education: <Education resumeEducation={resume.education} />,
+        awards: <Awards resumeAwards={resume.awards} />,
+        publications: <Publications resumePublications={resume.publications} />,
+        projects: <Projects resumeProjects={resume.projects} />,
+        references: <References resumeReferences={resume.references} />,
+    }
+
+    const sidebarItems = sidebarOrder.map((section) => sidebarMapping[section])
+    const mainSectionItems = mainSectionOrder.map(
+        (section) => mainSectionMapping[section]
+    )
     return (
         <main id="resume" class="page">
             <ResumeHeader resumeBasics={resume.basics} />
             <div class="resume-content">
-                <aside class="left-column">
-                    <About
-                        resumeBasics={resume.basics}
-                        countryFormatters={countryFormatters}
-                    />
-                    <Skills resumeSkills={resume.skills} />
-                    <Languages resumeLanguages={resume.languages} />
-                    <Interests resumeInterests={resume.interests} />
-                </aside>
-                <div class="right-column">
-                    <Summary resumeSummary={resume.basics?.summary} />
-                    <Work resumeWork={resume.work} />
-                    <Volunteer resumeVolunteer={resume.volunteer} />
-                    <Education resumeEducation={resume.education} />
-                    <Awards resumeAwards={resume.awards} />
-                    <Publications resumePublications={resume.publications} />
-                    <Projects resumeProjects={resume.projects} />
-                    <References resumeReferences={resume.references} />
-                </div>
+                <aside class="left-column">{sidebarItems}</aside>
+                <div class="right-column">{mainSectionItems}</div>
             </div>
         </main>
     )

--- a/src/types/resume-meta.ts
+++ b/src/types/resume-meta.ts
@@ -1,10 +1,23 @@
 import type { ResumeSchema } from '/@/types/resume'
 
+type MainSectionNames =
+    | 'summary'
+    | 'work'
+    | 'volunteer'
+    | 'education'
+    | 'awards'
+    | 'publications'
+    | 'projects'
+    | 'references'
+
+type SidebarNames = 'about' | 'skills' | 'languages' | 'interests'
 /**
  * Extension of ResumeSchema['meta'] field with extra custom data.
  */
 export type ColdbrewResumeMeta = Exclude<ResumeSchema['meta'], undefined> & {
     coldbrewTheme?: {
         locale?: string
+        mainSectionOrder?: MainSectionNames[]
+        sidebarOrder?: SidebarNames[]
     }
 }


### PR DESCRIPTION
Added a feature to change the ordering of sections in the resume.

In the resume JSON's `meta.coldbrewTheme` object:
- `sidebarOrder`: a list of sections to order in the left sidebar
- `mainSectionOrder`: a list of sections in order for the resume body